### PR TITLE
Add UX studio landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RawInsight - UX Studio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="logo">RawInsight</div>
+    <nav class="nav-links" id="navLinks">
+      <a href="#services">Services</a>
+      <a href="#about">About</a>
+      <a href="#contact">Contact</a>
+    </nav>
+    <button class="burger" id="burger" aria-label="Toggle navigation">
+      <span></span><span></span><span></span>
+    </button>
+  </header>
 
+  <main>
+    <section class="hero section">
+      <div class="content">
+        <h1>Crafting clarity in every interface</h1>
+        <p class="subheading">Partner with a UX studio that puts real users first.</p>
+        <a href="#contact" class="cta-button">Work with us</a>
+      </div>
+    </section>
+
+    <section id="services" class="services section">
+      <h2>What we offer</h2>
+      <ul>
+        <li>Rapid usability testing for new concepts</li>
+        <li>UX audits that pinpoint friction points</li>
+        <li>Design support for early-stage prototypes</li>
+        <li>Consulting for focused product teams</li>
+      </ul>
+    </section>
+
+    <section id="about" class="about section">
+      <h2>About RawInsight</h2>
+      <p>I'm a product-focused designer dedicated to bridging the gap between teams and their users. My approach is grounded in research and clear communication, helping you create experiences people love to use.</p>
+    </section>
+
+    <section id="contact" class="contact section">
+      <h2>Let's collaborate</h2>
+      <form action="https://formspree.io/f/mqabpdya" method="POST">
+        <label>
+          Name
+          <input type="text" name="name" required>
+        </label>
+        <label>
+          Email
+          <input type="email" name="email" required>
+        </label>
+        <label>
+          Message
+          <textarea name="message" rows="5" required></textarea>
+        </label>
+        <button type="submit" class="cta-button">Send Message</button>
+      </form>
+    </section>
+
+    <section class="newsletter section">
+      <h2>Stay in the loop</h2>
+      <p>Be the first to know when our newsletter launches.</p>
+      <form class="newsletter-form">
+        <input type="email" placeholder="Your email" disabled>
+        <button type="button" class="cta-button" disabled>Subscribe</button>
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <span>© 2025 RawInsight</span>
+      <div class="social">
+        <a href="#">Twitter</a>
+        <a href="#">LinkedIn</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
 <body>
   <header class="site-header">
     <div class="logo">RawInsight</div>
-    <nav class="nav-links" id="navLinks">
-      <a href="#services">Services</a>
-      <a href="#about">About</a>
-      <a href="#contact">Contact</a>
+    <nav class="nav-links" id="navLinks" aria-label="Main navigation">
+      <a href="#services" class="nav-link">Services</a>
+      <a href="#about" class="nav-link">About</a>
+      <a href="#contact" class="nav-link">Contact</a>
     </nav>
-    <button class="burger" id="burger" aria-label="Toggle navigation">
+    <button class="burger" id="burger" aria-label="Toggle navigation" aria-controls="navLinks" aria-expanded="false">
       <span></span><span></span><span></span>
     </button>
   </header>
@@ -27,7 +27,7 @@
       <div class="content">
         <h1>Crafting clarity in every interface</h1>
         <p class="subheading">Partner with a UX studio that puts real users first.</p>
-        <a href="#contact" class="cta-button">Work with us</a>
+        <a id="hero-cta" href="#contact" class="cta-button">Work with us</a>
       </div>
     </section>
 
@@ -48,7 +48,7 @@
 
     <section id="contact" class="contact section">
       <h2>Let's collaborate</h2>
-      <form action="https://formspree.io/f/mqabpdya" method="POST">
+      <form aria-label="Contact form" action="https://formspree.io/f/mqabpdya" method="POST">
         <label>
           Name
           <input type="text" name="name" required>
@@ -68,7 +68,7 @@
     <section class="newsletter section">
       <h2>Stay in the loop</h2>
       <p>Be the first to know when our newsletter launches.</p>
-      <form class="newsletter-form">
+      <form aria-label="Newsletter signup" class="newsletter-form">
         <input type="email" placeholder="Your email" disabled>
         <button type="button" class="cta-button" disabled>Subscribe</button>
       </form>
@@ -85,6 +85,6 @@
     </div>
   </footer>
 
-  <script src="script.js"></script>
+  <script src="script.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,9 +1,27 @@
 const burger = document.getElementById('burger');
 const navLinks = document.getElementById('navLinks');
+const navAnchors = navLinks.querySelectorAll('a');
 
 burger.addEventListener('click', () => {
+  const expanded = burger.getAttribute('aria-expanded') === 'true';
+  burger.setAttribute('aria-expanded', (!expanded).toString());
   navLinks.classList.toggle('open');
 });
+
+navAnchors.forEach(link => {
+  link.addEventListener('click', () => {
+    navLinks.classList.remove('open');
+    burger.setAttribute('aria-expanded', 'false');
+  });
+});
+
+const heroCTA = document.getElementById('hero-cta');
+if (heroCTA) {
+  heroCTA.addEventListener('click', e => {
+    e.preventDefault();
+    document.getElementById('contact').scrollIntoView({ behavior: 'smooth' });
+  });
+}
 
 const observer = new IntersectionObserver(entries => {
   entries.forEach(entry => {

--- a/script.js
+++ b/script.js
@@ -1,1 +1,18 @@
+const burger = document.getElementById('burger');
+const navLinks = document.getElementById('navLinks');
 
+burger.addEventListener('click', () => {
+  navLinks.classList.toggle('open');
+});
+
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('show');
+    }
+  });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.section').forEach(section => {
+  observer.observe(section);
+});

--- a/style.css
+++ b/style.css
@@ -1,3 +1,10 @@
+:root {
+  --bg-color: #0f1115;
+  --text-color: #f5f5f5;
+  --accent-bg: #fff;
+  --accent-text: #000;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -5,8 +12,8 @@
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  background: #0f1115;
-  color: #f5f5f5;
+  background: var(--bg-color);
+  color: var(--text-color);
   scroll-behavior: smooth;
 }
 
@@ -18,7 +25,7 @@ header.site-header {
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background: #0f1115;
+  background: var(--bg-color);
   border-bottom: 1px solid #222;
 }
 
@@ -30,7 +37,7 @@ header.site-header {
 .nav-links a {
   margin-left: 1.5rem;
   text-decoration: none;
-  color: #f5f5f5;
+  color: var(--text-color);
   font-weight: 500;
 }
 
@@ -47,7 +54,7 @@ header.site-header {
 .burger span {
   display: block;
   height: 3px;
-  background: #f5f5f5;
+  background: var(--text-color);
 }
 
 main {
@@ -58,11 +65,16 @@ main {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4rem 2rem;
+  padding: 6rem 2rem;
   scroll-snap-align: start;
   opacity: 0;
   transform: translateY(20px);
   transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+.section .content {
+  max-width: 700px;
+  margin: 0 auto;
+  text-align: center;
 }
 .section.show {
   opacity: 1;
@@ -82,14 +94,22 @@ main {
   font-size: 1.25rem;
 }
 .cta-button {
-  background: #fff;
-  color: #000;
-  padding: 0.75rem 1.5rem;
+  background: var(--accent-bg);
+  color: var(--accent-text);
+  padding: 0.85rem 1.75rem;
   border: none;
+  border-radius: 4px;
   font-weight: 600;
+  font-size: 1rem;
   cursor: pointer;
   text-decoration: none;
   display: inline-block;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.cta-button:hover {
+  background: var(--text-color);
+  color: var(--bg-color);
 }
 
 .services h2,
@@ -133,8 +153,8 @@ main {
 .contact textarea {
   padding: 0.5rem;
   border: 1px solid #555;
-  background: #0f1115;
-  color: #f5f5f5;
+  background: var(--bg-color);
+  color: var(--text-color);
   font-family: 'Inter', sans-serif;
 }
 .contact button {
@@ -143,14 +163,17 @@ main {
 
 .newsletter-form {
   display: flex;
-  gap: 0.5rem;
+  margin-top: 1rem;
+  gap: 0.75rem;
   justify-content: center;
 }
 .newsletter-form input {
   padding: 0.5rem;
+  border-radius: 4px;
+  width: 250px;
   border: 1px solid #555;
-  background: #0f1115;
-  color: #f5f5f5;
+  background: var(--bg-color);
+  color: var(--text-color);
 }
 
 .site-footer {
@@ -165,7 +188,7 @@ main {
   align-items: center;
 }
 .footer-inner a {
-  color: #f5f5f5;
+  color: var(--text-color);
   margin-left: 1rem;
   text-decoration: none;
 }
@@ -177,7 +200,7 @@ main {
     position: absolute;
     top: 60px;
     right: 20px;
-    background: #0f1115;
+    background: var(--bg-color);
     border: 1px solid #222;
     padding: 1rem;
   }

--- a/style.css
+++ b/style.css
@@ -1,1 +1,190 @@
+* {
+  box-sizing: border-box;
+}
 
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: #0f1115;
+  color: #f5f5f5;
+  scroll-behavior: smooth;
+}
+
+header.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: #0f1115;
+  border-bottom: 1px solid #222;
+}
+
+.logo {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.5rem;
+}
+
+.nav-links a {
+  margin-left: 1.5rem;
+  text-decoration: none;
+  color: #f5f5f5;
+  font-weight: 500;
+}
+
+.burger {
+  display: none;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 24px;
+  height: 18px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.burger span {
+  display: block;
+  height: 3px;
+  background: #f5f5f5;
+}
+
+main {
+  scroll-snap-type: y mandatory;
+}
+.section {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  scroll-snap-align: start;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+.section.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+.hero .subheading {
+  max-width: 600px;
+  margin: 0 auto 2rem;
+  text-align: center;
+  font-size: 1.25rem;
+}
+.cta-button {
+  background: #fff;
+  color: #000;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.services h2,
+.about h2,
+.contact h2,
+.newsletter h2 {
+  font-family: 'Playfair Display', serif;
+  text-align: center;
+  margin-bottom: 2rem;
+}
+.services ul {
+  list-style: none;
+  padding: 0;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.services li {
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.about p {
+  max-width: 650px;
+  margin: 0 auto;
+  text-align: center;
+  line-height: 1.6;
+}
+
+.contact form {
+  max-width: 600px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+}
+.contact label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 500;
+}
+.contact input,
+.contact textarea {
+  padding: 0.5rem;
+  border: 1px solid #555;
+  background: #0f1115;
+  color: #f5f5f5;
+  font-family: 'Inter', sans-serif;
+}
+.contact button {
+  justify-self: start;
+}
+
+.newsletter-form {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+.newsletter-form input {
+  padding: 0.5rem;
+  border: 1px solid #555;
+  background: #0f1115;
+  color: #f5f5f5;
+}
+
+.site-footer {
+  border-top: 1px solid #222;
+  padding: 2rem;
+}
+.footer-inner {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.footer-inner a {
+  color: #f5f5f5;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 60px;
+    right: 20px;
+    background: #0f1115;
+    border: 1px solid #222;
+    padding: 1rem;
+  }
+  .nav-links.open {
+    display: flex;
+  }
+  .burger {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## Summary
- build simple single-page landing site for RawInsight UX studio
- style with dark theme, Playfair Display headings and Inter body text
- add scroll-snap sections with fade-in animation
- include Formspree contact form and placeholder newsletter form
- implement responsive burger menu navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474e92a17083268b350c84cc4de6c6